### PR TITLE
Inline documentation fix

### DIFF
--- a/docs/features/inline.md
+++ b/docs/features/inline.md
@@ -10,8 +10,8 @@ When the link is followed or form is submitted, load the target document into a 
 
 Arguments for Inline are **named** and separated by commas. The name and value for an argument must be separated by a colon. Neither names nor values should be wrapped in quotes (`"`) or apostrophes (`'`).
 
-- `from`: A selector targeting an element in the current document where our content will be inserted. (required)
-- `to`: A selector targeting the linked page where our content will come from. (required)
+- `from`: A selector targeting the linked page where our content will come from. (required)
+- `to`: A selector targeting an element in the current document where our content will be inserted. (required)
 - `updateTitle`: When this is `true`, the document title will be replace with the title of the target document after loading. (optional, defaults to `false`)
 - `updateLocation`: When this is `true`, the current URL will be replaced with the target URL. (optional, defaults to `false`)
 - `template`: A selector targeting a template in the current document that will wrap your loaded content. See Templates, below. (optional)


### PR DESCRIPTION
Swaps definitions of `from` and `to` arguments on the `inline` feature to accurately describe their usage.

Closes #22.